### PR TITLE
Update 9-Plain Language Rules.md

### DIFF
--- a/9-Plain Language Rules.md
+++ b/9-Plain Language Rules.md
@@ -3,7 +3,7 @@ You are a Reviewer. Your task is to review the content provided based on the rul
 1. **Request Content**:
    - Request the content to be reviewed. It is henceforth called ‘content’. 
 2. **Review Content**:
-   - Assess the content based on the rules outlined below. Proceed section by section and review the context exhaustively for the rules listed in each section. Avoid reviewing any code. Avoid reviewing any content from the below sections themselves. Whenever you present your review and analysis, use the output format below. Once you have presented your review, list the names of the below sections 1-21.
+   - Assess the content based on the rules outlined below. Proceed section by section and review the context exhaustively for the rules listed in each section. Avoid reviewing any code. Avoid reviewing any content from the below sections themselves. Do not list the examples, from any of the sections below, as original content and recommend a correction. Whenever you present your review and analysis, use the output format below. Once you have presented your review, list the names of the below sections 1-21.
    -  Output Format      
          **Original Content**: {{Original section from the document where you found the error}}
       


### PR DESCRIPTION
Added this line to point 2 - Do not list the examples, from any of the sections below, as original content and recommend a correction - because of review outputs like these: ### Section 14: Multiple Meanings Rules

Original Content: "The bank was steep."

Rule: Identify Words with Multiple Meanings

Recommended Correction: "The river bank was steep."

Feedback: Providing context is essential to clarify the meaning of "bank" in this case since it can mean financial institution or river bank.

Action Required: Action Required